### PR TITLE
Revert bof_argument_array_parameter_name change

### DIFF
--- a/Payload_Type/forge/payload_type_support.json
+++ b/Payload_Type/forge/payload_type_support.json
@@ -16,7 +16,7 @@
 		"agent": "athena",
 		"bof_command": "coff",
 		"bof_file_parameter_name": "coffFile",
-		"bof_argument_array_parameter_name": "arguments",
+		"bof_argument_array_parameter_name": "argument_array",
 		"bof_entrypoint_parameter_name": "functionName",
 		"inline_assembly_command": "",
 		"inline_assembly_file_parameter_name": "",


### PR DESCRIPTION
The issue has been addressed in the athena agent code, `argument_array` is the correct way to pass forge_bof arguments to athena